### PR TITLE
Updating CIC to latest image

### DIFF
--- a/charts/examples/citrix-k8s-cpx-ingress-controller/Chart.yaml
+++ b/charts/examples/citrix-k8s-cpx-ingress-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.5.25"
 description: A Helm chart for Citrix ADC CPX with inbuilt ingress Controller
 name: citrix-k8s-cpx-ingress-controller
-version: 1.0.0
+version: 1.5.25
 home: https://www.citrix.com
 sources:
 - https://github.com/citrix/citrix-k8s-ingress-controller

--- a/charts/examples/citrix-k8s-cpx-ingress-controller/README.md
+++ b/charts/examples/citrix-k8s-cpx-ingress-controller/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the CPX with inBuilt In
 |```license.accept```|Set to accept to accept the terms of the Citrix license| ```no``` |
 |```cpx.image```| CPX Image Repository| ```quay.io/citrix/citrix-k8s-cpx-ingress:13.0-36.29```|
 |```cpx.pullPolicy```| CPX Image Pull Policy  | ```Always``` |
-|```cic.image```| CIC Image Repository| ```quay.io/citrix/citrix-k8s-ingress-controller:1.4.392```|
+|```cic.image```| CIC Image Repository| ```quay.io/citrix/citrix-k8s-ingress-controller:1.5.25```|
 |```cic.pullPolicy```| CIC Image Pull Policy  | ```Always``` |
 |```cic.required```| CIC to be run as sidecar with Citrix ADC CPX| ```true```|
 |```exporter.required```|Exporter to be run as sidecar with Citrix ADC CPX and CIC|```false```|

--- a/charts/examples/citrix-k8s-cpx-ingress-controller/values.yaml
+++ b/charts/examples/citrix-k8s-cpx-ingress-controller/values.yaml
@@ -5,7 +5,7 @@ cpx:
   image: quay.io/citrix/citrix-k8s-cpx-ingress:13.0-36.29
   pullPolicy: Always
 cic:
-  image: quay.io/citrix/citrix-k8s-ingress-controller:1.4.392
+  image: quay.io/citrix/citrix-k8s-ingress-controller:1.5.25
   pullPolicy: Always
   required: true
 license:

--- a/charts/examples/citrix-k8s-ingress-controller/Chart.yaml
+++ b/charts/examples/citrix-k8s-ingress-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.5.25"
 description: A Helm chart for Citrix Ingress Controller configuring MPX/VPX 
 name: citrix-k8s-ingress-controller
-version: 1.0.0
+version: 1.5.25
 home: https://www.citrix.com
 sources:
 - https://github.com/citrix/citrix-k8s-ingress-controller

--- a/charts/examples/citrix-k8s-ingress-controller/README.md
+++ b/charts/examples/citrix-k8s-ingress-controller/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Citrix Ingress Cont
 | Parameter |    Description | Default |
 | --------- |  ---------------- | ------- |
 |```license.accept```|Set to accept to accept the terms of the Citrix license|```no```|
-| ``` cic.image ``` | Image Repository|```quay.io/citrix/citrix-k8s-ingress-controller:1.4.392```|
+| ``` cic.image ``` | Image Repository|```quay.io/citrix/citrix-k8s-ingress-controller:1.5.25```|
 |```  cic.pullPolicy```| Image Pull Policy  |```Always```|
 |```loginFileName```| Secret keys for login into NetScaler VPX or MPX Refer Secret Keys|```nslogin```|
 |```nsIP```|NetScaler VPX/MPX IP|```x.x.x.x```|

--- a/charts/examples/citrix-k8s-ingress-controller/values.yaml
+++ b/charts/examples/citrix-k8s-ingress-controller/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 cic:
-  image: quay.io/citrix/citrix-k8s-ingress-controller:1.4.392
+  image: quay.io/citrix/citrix-k8s-ingress-controller:1.5.25
   pullPolicy: Always
 loginFileName: # secret file for NetScaler login
 nsIP: x.x.x.x # Set NetScaler NSIP/SNIP, SNIP in case of HA (mgmt has to be enabled) 

--- a/charts/stable/citrix-k8s-cpx-ingress-controller/Chart.yaml
+++ b/charts/stable/citrix-k8s-cpx-ingress-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.4.392"
+appVersion: "1.5.25"
 description: A Helm chart for Citrix ADC CPX with Citrix ingress Controller running as sidecar.
 name: citrix-k8s-cpx-ingress-controller
-version: 1.4.392
+version: 1.5.25
 icon: https://raw.githubusercontent.com/citrix/citrix-k8s-ingress-controller/gh-pages/icon.png
 home: https://www.citrix.com
 sources:

--- a/charts/stable/citrix-k8s-cpx-ingress-controller/README.md
+++ b/charts/stable/citrix-k8s-cpx-ingress-controller/README.md
@@ -111,7 +111,7 @@ The following table lists the configurable parameters of the Citrix ADC CPX with
 | lsIP | Optional | N/A | Provide the Citrix Application Delivery Management (ADM) IP address to license Citrix ADC CPX. For more information, see [Licensing](https://developer-docs.citrix.com/projects/citrix-k8s-ingress-controller/en/latest/licensing/)|
 | lsPort | Optional | 27000 | Citrix ADM port if non-default port is used. |
 | platform | Optional | N/A | Platform license. The platform is **CP1000**. |
-| cic.image | Mandatory | `quay.io/citrix/citrix-k8s-ingress-controller:1.4.392` | The Citrix ingress controller image. |
+| cic.image | Mandatory | `quay.io/citrix/citrix-k8s-ingress-controller:1.5.25` | The Citrix ingress controller image. |
 | cic.pullPolicy | Mandatory | Always | The Citrix ingress controller image pull policy. |
 | cic.required | Mandatory | true | CIC to be run as sidecar with Citrix ADC CPX |
 | defaultSSLCert | Optional | N/A | Default SSL certificate that needs to be used as a non-SNI certificate in Citrix ADC. |

--- a/charts/stable/citrix-k8s-cpx-ingress-controller/values.yaml
+++ b/charts/stable/citrix-k8s-cpx-ingress-controller/values.yaml
@@ -8,7 +8,7 @@ cpx:
   pullPolicy: Always
 # cicimage contains information needed to fetch CIC image
 cic:
-  image: quay.io/citrix/citrix-k8s-ingress-controller:1.4.392
+  image: quay.io/citrix/citrix-k8s-ingress-controller:1.5.25
   pullPolicy: Always
   required: true
 # openshift is set to true if charts are being deployed in OpenShift environment.

--- a/charts/stable/citrix-k8s-ingress-controller/Chart.yaml
+++ b/charts/stable/citrix-k8s-ingress-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.4.392"
+appVersion: "1.5.25"
 description: A Helm chart for Citrix Ingress Controller configuring MPX/VPX 
 name: citrix-k8s-ingress-controller
-version: 1.4.392
+version: 1.5.25
 icon: https://raw.githubusercontent.com/citrix/citrix-k8s-ingress-controller/gh-pages/icon.png
 home: https://www.citrix.com
 sources:

--- a/charts/stable/citrix-k8s-ingress-controller/README.md
+++ b/charts/stable/citrix-k8s-ingress-controller/README.md
@@ -170,7 +170,7 @@ The following table lists the mandatory and optional parameters that you can con
 | Parameters | Mandatory or Optional | Default value | Description |
 | --------- | --------------------- | ------------- | ----------- |
 | license.accept | Mandatory | no | Set `yes` to accept the CIC end user license agreement. |
-| cic.image | Mandatory | `quay.io/citrix/citrix-k8s-ingress-controller:1.4.392` | The CIC image. |
+| cic.image | Mandatory | `quay.io/citrix/citrix-k8s-ingress-controller:1.5.25` | The CIC image. |
 | cic.pullPolicy | Mandatory | Always | The CIC image pull policy. |
 | loginFileName | Mandatory | nslogin | The secret key to log on to the Citrix ADC VPX or MPX. For information on how to create the secret keys, see [Prerequisites](#prerequistes). |
 | nsIP | Mandatory | N/A | The IP address of the Citrix ADC device. For details, see [Prerequisites](#prerequistes). |

--- a/charts/stable/citrix-k8s-ingress-controller/values.yaml
+++ b/charts/stable/citrix-k8s-ingress-controller/values.yaml
@@ -4,7 +4,7 @@
 
 # image contains information needed to fetch CIC image
 cic:
-  image: quay.io/citrix/citrix-k8s-ingress-controller:1.4.392
+  image: quay.io/citrix/citrix-k8s-ingress-controller:1.5.25
   pullPolicy: Always
 # openshift is set to true if charts are being deployed in OpenShift environment.
 openshift: false

--- a/deployment/baremetal/README.md
+++ b/deployment/baremetal/README.md
@@ -166,7 +166,7 @@ CPX with a builtin Citrix Ingress Controller agent that configures the CPX. CPX 
 
    This pulls the latest image and brings up the Citrix Ingress Controller.
                 
-   Official Citrix Ingress Controller docker images is <span style="color:red"> `quay.io/citrix/citrix-k8s-ingress-controller:1.4.392` </span>
+   Official Citrix Ingress Controller docker images is <span style="color:red"> `quay.io/citrix/citrix-k8s-ingress-controller:1.5.25` </span>
 
 4. #### Reachability to the Pod Network
 

--- a/deployment/baremetal/citrix-k8s-cpx-ingress.yml
+++ b/deployment/baremetal/citrix-k8s-cpx-ingress.yml
@@ -86,7 +86,7 @@ spec:
           imagePullPolicy: Always
         # Add cic as a sidecar
         - name: cic
-          image: "quay.io/citrix/citrix-k8s-ingress-controller:1.4.392"
+          image: "quay.io/citrix/citrix-k8s-ingress-controller:1.5.25"
           env:
           - name: "EULA"
             value: "yes"

--- a/deployment/baremetal/citrix-k8s-ingress-controller.yaml
+++ b/deployment/baremetal/citrix-k8s-ingress-controller.yaml
@@ -67,7 +67,7 @@ spec:
       serviceAccountName: cic-k8s-role
       containers:
       - name: cic-k8s-ingress-controller
-        image: "quay.io/citrix/citrix-k8s-ingress-controller:1.4.392"
+        image: "quay.io/citrix/citrix-k8s-ingress-controller:1.5.25"
         env:
          # Set NetScaler NSIP/SNIP, SNIP in case of HA (mgmt has to be enabled) 
          - name: "NS_IP"


### PR DESCRIPTION
Updated `quay.io/citrix/citrix-k8s-ingress-controller:1.4.392` to `quay.io/citrix/citrix-k8s-ingress-controller:1.5.25`