### PR TITLE
Modified Pod yaml to Deployment and updated the apiversion to apps/v1

### DIFF
--- a/deployment/baremetal/citrix-k8s-cpx-ingress.yml
+++ b/deployment/baremetal/citrix-k8s-cpx-ingress.yml
@@ -59,11 +59,14 @@ metadata:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cpx-ingress
 spec:
+  selector:
+    matchLabels:
+      app: cpx-ingress
   replicas: 1
   template:
     metadata:

--- a/deployment/baremetal/citrix-k8s-ingress-controller.yaml
+++ b/deployment/baremetal/citrix-k8s-ingress-controller.yaml
@@ -61,9 +61,18 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: cic-k8s-ingress-controller
-  labels:
-    app: cic-k8s-ingress-controller
-spec: 
+spec:
+  selector:
+    matchLabels:
+      app: cic-k8s-ingress-controller
+  replicas: 1
+  template:
+    metadata:
+      name: cic-k8s-ingress-controller
+      labels:
+        app: cic-k8s-ingress-controller
+      annotations:
+    spec: 
       serviceAccountName: cic-k8s-role
       containers:
       - name: cic-k8s-ingress-controller

--- a/deployment/baremetal/citrix-k8s-ingress-controller.yaml
+++ b/deployment/baremetal/citrix-k8s-ingress-controller.yaml
@@ -57,8 +57,8 @@ metadata:
   namespace: default
 
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: cic-k8s-ingress-controller
 spec:


### PR DESCRIPTION
Testing done:

1. Applied citrix-k8s-ingress-controller.yaml and citrix-k8s-cpx-ingress.yml, and then checked the deployment is created with one instance

Output:
root@ubuntu-232:~/deepak/cpx# kubectl get deployment
NAME                         DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
apache                       8         8         8            8           98d
cic-k8s-ingress-controller   1         1         1            0           15m
cpx-ingress                  1         1         1            0           12s

2. Changed the selector name to different name than label and see that Deployment is not created(as expected).