### PR TITLE
Updating RBAC api version

### DIFF
--- a/deployment/baremetal/citrix-k8s-cpx-ingress.yml
+++ b/deployment/baremetal/citrix-k8s-cpx-ingress.yml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cpx-ingress-k8s-role
 rules:
@@ -48,7 +48,7 @@ rules:
 ---
 
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cpx-ingress-k8s-role
 roleRef:


### PR DESCRIPTION
Existing apiversion is deprecated and being removed in v1.22
Please refer https://kubernetes.io/docs/reference/using-api/deprecation-guide/ for the announcement.


Testing status:
Able to deploy CPX-CIC using my proposed change.