### PR TITLE
cic version update from 1.16.9 to 1.17.13

### DIFF
--- a/deployment/baremetal/README.md
+++ b/deployment/baremetal/README.md
@@ -213,7 +213,7 @@ Perform the following steps to deploy the Citrix ingress controller as a stand-a
     This command pulls the latest image and brings up the Citrix ingress controller.
                 
 
-    The official Citrix ingress controller docker image is available at: <span style="color:red"> `quay.io/citrix/citrix-k8s-ingress-controller:1.16.9` </span>
+    The official Citrix ingress controller docker image is available at: <span style="color:red"> `quay.io/citrix/citrix-k8s-ingress-controller:1.17.13` </span>
 
 
 2. Configure reachability to the pod network using one of the following.

--- a/deployment/baremetal/citrix-k8s-cpx-ingress.yml
+++ b/deployment/baremetal/citrix-k8s-cpx-ingress.yml
@@ -107,7 +107,7 @@ spec:
               name: cpx-volume
         # Add cic as a sidecar
         - name: cic
-          image: quay.io/citrix/citrix-k8s-ingress-controller:1.16.9
+          image: quay.io/citrix/citrix-k8s-ingress-controller:1.17.13
           volumeMounts:
           - mountPath: /var/deviceinfo
             name: shared-data

--- a/deployment/baremetal/citrix-k8s-ingress-controller.yaml
+++ b/deployment/baremetal/citrix-k8s-ingress-controller.yaml
@@ -85,7 +85,7 @@ spec:
       serviceAccountName: cic-k8s-role
       containers:
       - name: cic-k8s-ingress-controller
-        image: "quay.io/citrix/citrix-k8s-ingress-controller:1.16.9"
+        image: "quay.io/citrix/citrix-k8s-ingress-controller:1.17.13"
         env:
          # Set NetScaler NSIP/SNIP, SNIP in case of HA (mgmt has to be enabled) 
          - name: "NS_IP"

--- a/deployment/baremetal/yaml-cpx-crediential-changes/cpx-cic-previous.yaml
+++ b/deployment/baremetal/yaml-cpx-crediential-changes/cpx-cic-previous.yaml
@@ -106,7 +106,7 @@ spec:
               name: cpx-volume2
         # Add cic as a sidecar
         - name: cic
-          image: quay.io/citrix/citrix-k8s-ingress-controller:1.16.9
+          image: quay.io/citrix/citrix-k8s-ingress-controller:1.17.13
           args:
           - --ingress-classes
               citrix


### PR DESCRIPTION
…x/citrix-k8s-ingress-controller:1.16.9 to quay.io/citrix/citrix-k8s-ingress-controller:1.17.13 and CPX from: quay.io/citrix/citrix-k8s-cpx-ingress:13.0-76.29 to quay.io/citrix/citrix-k8s-cpx-ingress:13.0-79.64.