### PR TITLE
updated the command policy with  policy provided in helm chart docs

### DIFF
--- a/docs/deploy/deploy-cic-yaml.md
+++ b/docs/deploy/deploy-cic-yaml.md
@@ -57,10 +57,10 @@ To create the system user account, perform the following:
 
 1.  Create a policy to provide required permissions to the system user account. Use the following command:
 
-        add cmdpolicy cic-policy ALLOW "^(\?!shell)(\?!sftp)(\?!scp)(\?!batch)(\?!source)(\?!.*superuser)(\?!.*nsroot)(\?!install)(\?!show\s+system\s+(user|cmdPolicy|file))(\?!(set|add|rm|create|export|kill)\s+system)(\?!(unbind|bind)\s+system\s+(user|group))(\?!diff\s+ns\s+config)(\?!(set|unset|add|rm|bind|unbind|switch)\s+ns\s+partition).*|(^install\s*(wi|wf))|(^(add|show|rm)\s+system\s+file)|(stat ns globalcntr -counters sys_cur_duration_sincestart)"
+        add cmdpolicy cic-policy ALLOW "(^\S+\s+cs\s+\S+)|(^\S+\s+lb\s+\S+)|(^\S+\s+service\s+\S+)|(^\S+\s+servicegroup\s+\S+)|(^stat\s+system)|(^show\s+ha)|(^\S+\s+ssl\s+certKey)|(^\S+\s+ssl)|(^\S+\s+route)|(^\S+\s+monitor)|(^show\s+ns\s+ip)|(^\S+\s+system\s+file)"
 
     !!! note "Note"
-        The system user account would have privileges based on the command policy that you define. The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with additional permission to upload files.
+        The system user account would have privileges based on the command policy that you define.
 
 1.  Bind the policy to the system user account using the following command:
 


### PR DESCRIPTION
Updated the command policy with the one mentioned in Helm chart docs. (https://github.com/citrix/citrix-helm-charts/tree/master/citrix-ingress-controller#create-system-user-account-for-citrix-ingress-controller-in-citrix-adc)
This policy has the required minimum permissions.