### PR TITLE
doc changes for CIC release 1.21.9

### DIFF
--- a/deployment/openshift/README.md
+++ b/deployment/openshift/README.md
@@ -86,8 +86,6 @@ You can use the [cic.yaml](https://raw.githubusercontent.com/citrix/citrix-k8s-i
 
 **Note:** The Citrix ADC MPX or VPX can be deployed in *[standalone](https://docs.citrix.com/en-us/citrix-adc/12-1/getting-started-with-citrix-adc.html)*, *[high-availability](https://docs.citrix.com/en-us/citrix-adc/12-1/getting-started-with-citrix-adc/configure-ha-first-time.html)*, or *[clustered](https://docs.citrix.com/en-us/citrix-adc/12-1/clustering.html)* modes.
 
-**Note:** In the latest versions of OpenShift when OVN CNI is used, `—feature-node-watch` might not work. In that case, you must manually configure the static routes on Citrix ADC VPX.
-
 ### Prerequisites
 
 -  Determine the IP address needed by the Citrix ingress controller to communicate with the Citrix ADC appliance. The IP address might be any one of the following depending on the type of Citrix ADC deployment:

--- a/docs/deploy/deploy-cic-openshift.md
+++ b/docs/deploy/deploy-cic-openshift.md
@@ -119,8 +119,6 @@ You can use the [cic.yaml](https://raw.githubusercontent.com/citrix/citrix-k8s-i
 
 **Note:** The Citrix ADC MPX or VPX can be deployed in *[standalone](https://docs.citrix.com/en-us/citrix-adc/12-1/getting-started-with-citrix-adc.html)*, *[high-availability](https://docs.citrix.com/en-us/citrix-adc/12-1/getting-started-with-citrix-adc/configure-ha-first-time.html)*, or *[clustered](https://docs.citrix.com/en-us/citrix-adc/12-1/clustering.html)* modes.
 
-**Note:** In the latest versions of OpenShift when OVN CNI is used, `—feature-node-watch` might not work. In that case, you must manually configure the static routes on Citrix ADC VPX.
-
 ### Prerequisites
 
 -  Determine the IP address needed by the Citrix ingress controller to communicate with the Citrix ADC appliance. The IP address might be any one of the following depending on the type of Citrix ADC deployment:

--- a/docs/multicluster/multi-cluster.md
+++ b/docs/multicluster/multi-cluster.md
@@ -397,12 +397,13 @@ The following table explains the GTP CRD attributes.
 |`serviceType: `          |Specifies the protocol to which multi-cluster support is applied.                                                                                                                                                                                                                                                                  |
 | `host `          |                                                                                           Specifies the domain for which multi-cluster support is applied.                                                                                                                                |
 | `trafficPolicy`    | Specifies the traffic distribution policy supported in a multi-cluster deployment. |
+| `sourceIpPersistenceId`| Specifies the unique source IP persistence ID. This attribute enables persistence based on the source IP address for the inbound packets. The `sourceIpPersistenceId ` attribute should be a multiple of 100 and should be unique.  For a sample configuration, see [Example: source IP persistence](#example-source-ip-persistence). |
 | `secLbMethod`    |  Specifies the traffic distribution policy supported among clusters under a group in local-first, canary, or failover.  |
 |  `destination `        | Specifies the Ingress or LoadBalancer service endpoint in each cluster. The destination name should match with the name of GSE.                                                                                      |
 | `weight`               |  Specifies the proportion of traffic to be distributed across clusters. For canary deployment, the proportion is specified as percentage.                                                                                                                                                                                                                                                   |
 |`CIDR`    |Specifies the CIDR to be used in local-first to determine the scope of locality.                                                                                                                                                                                                                                                                                  |
 |`primary`    | Specifies whether the destination is a primary cluster or a backup cluster in the failover deployment.                                                                                                                                                                                                                                                                              |
-|`monType`    |Specifies the type of probe to determine the health of the multi-cluster endpoint.                                                                                                                                                                                                                                                                                  |
+|`monType`    |Specifies the type of probe to determine the health of the multi-cluster endpoint.  When the monitor type is HTTPS, SNI is enabled by default during the TLS handshake.                                                                               |
 |`uri`    |Specifies the path to be probed for the health of the multi-cluster endpoint for HTTP and HTTPS.                                                                                                                                                                                                                                                                                  |
 |`respCode`    |Specifies the response code expected to mark the multi-cluster endpoint as healthy for HTTP and HTTPS.                                                                                                                                                                                                               |
 
@@ -545,3 +546,28 @@ Following is a sample traffic policy for the static proximity deployment.
             uri: ''
             respCode: 200
 
+## Example: source IP persistence
+
+The following traffic policy provides an example for enabling source IP persistence support. Source IP persistence can be enabled by providing the parameter `sourceIpPersistenceId`. The source IP persistence attribute can be enabled with the supported traffic policies.
+
+    apiVersion: "citrix.com/v1beta1"
+    kind: globaltrafficpolicy
+    metadata
+      name: gtp1
+      namespace: default
+    spec:
+      serviceType: 'HTTP'
+      hosts:
+      - host: 'app2.com'
+        policy:
+          trafficPolicy: 'ROUNDROBIN'
+          sourceIpPersistenceId: 300
+          targets:
+          - destination: 'app2.default.east.cluster1'
+            weight: 2
+          - destination: 'app2.default.west.cluster2'
+            weight: 5
+          monitor:
+          - monType: tcp
+            uri: ''
+            respCode: 200

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -31,11 +31,12 @@ The following table describes some of the common issues and workarounds.
 
 ## Troubleshooting - OpenShift feature node watch
 
-Problem: While using OpenShift-ovn CNI `feature-node-watch` is not adding correct routes.
+**Problem 1**:
+While using OpenShift-ovn CNI `feature-node-watch` is not adding correct routes.
 
-Description: Citrix ingress controller looks for Node annotations for fetching the necessary details to add the static routes.
+**Description**: Citrix ingress controller looks for Node annotations for fetching the necessary details to add the static routes.
 
-Workaround:
+**Workaround**:
 
 1. Make sure that following RBAC permission is provided to Citrix ingress controller along with `route.openshift.io` for Citrix ingress controller to run in the OpenShift environment with OVN CNI.
 
@@ -51,12 +52,12 @@ cluster nodes.
 
 3. If the annotation does not exist `feature-node-watch`  might not work for OVN CNI. In that case, you must manually configure the static routes on Citrix ADC VPX.
 
-Problem: While using OpenShift-sdn CNI feature-node-watch is not adding 
-correct routes
+**Problem 2**:
+While using OpenShift-sdn CNI feature-node-watch is not adding correct routes
 
-Description: Citrix ingress controller looks for the Hostsubnet CRD for fetching the necessary details to add the static routes.
+**Description**: Citrix ingress controller looks for the Hostsubnet CRD for fetching the necessary details to add the static routes.
 
-Workaround:
+**Workaround**:
 
 1. Make sure that following RBAC permission is provided to Citrix ingress controller along with  `route.openshift.io` for Citrix ingress controller to run in the OpenShift environment with SDN CNI.
 

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -28,3 +28,56 @@ The following table describes some of the common issues and workarounds.
 |------|-----|-----|
 |Grafana dashboard has no plots|If the graphs on the Grafana dashboards do not have any values plotted, then Grafana is unable to obtain statistics from its datasource.| Check if the Prometheus datasource is saved and working properly. On saving the datasource after providing the Name and IP, a "Data source is working" message appears in green indicating the datasource is reachable and detected. <br>If the dashboard is created using `sample_grafana_dashboard.json`, ensure that the name given to the Prometheus datasource begins with the word "prometheus" in lowercase. <br>Check the Targets page of Prometheus to see if the required target exporter is in `DOWN` state.|
 | DOWN: Context deadline exceeded| If the message appears against any of the exporter targets of Prometheus, then Prometheus is either unable to connect to the exporter or unable to fetch all the metrics within the given `scrape_timeout`.|If you are using Prometheus Operator, `scrape_timeout` is adjusted automatically and the error means that the exporter itself is not reachable. <br>If a standalone Prometheus container or pod is used, try increasing the `scrape_interval` and `scrape_timeout` values in the `/etc/prometheus/prometheus.cfg` file to increase the time interval for collecting the metrics.|
+
+## Troubleshooting - OpenShift feature node watch
+
+Problem: While using OpenShift-ovn CNI `feature-node-watch` is not adding correct routes.
+
+Description: Citrix ingress controller looks for Node annotations for fetching the necessary details to add the static routes.
+
+Workaround:
+
+1. Make sure that following RBAC permission is provided to Citrix ingress controller along with `route.openshift.io` for Citrix ingress controller to run in the OpenShift environment with OVN CNI.
+
+        - apiGroups: ["config.openshift.io"]
+          resources: ["networks"]
+          verbs: ["get", "list"]
+
+2. Citrix ingress controller looks for the following two annotations added by OVN, make sure that it exists on the 
+cluster nodes.
+
+        "k8s.ovn.org/node-subnets": {\"default\":\"10.128.0.0/23\"}",
+        "k8s.ovn.org/node-primary-ifaddr": "{\"ipv4\":\"x.x.x.x/24\"}"
+
+3. If the annotation does not exist `feature-node-watch`  might not work for OVN CNI. In that case, you must manually configure the static routes on Citrix ADC VPX.
+
+Problem: While using OpenShift-sdn CNI feature-node-watch is not adding 
+correct routes
+
+Description: Citrix ingress controller looks for the Hostsubnet CRD for fetching the necessary details to add the static routes.
+
+Workaround:
+
+1. Make sure that following RBAC permission is provided to Citrix ingress controller along with  `route.openshift.io` for Citrix ingress controller to run in the OpenShift environment with SDN CNI.
+
+        - apiGroups: ["network.openshift.io"]
+          resources: ["hostsubnets"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["config.openshift.io"]
+          resources: ["networks"]
+          verbs: ["get", "list"]
+2. Citrix ingress controller looks for the following CRD and specification.
+
+            oc get hostsubnets.network.openshift.io <cluster node-name> -ojson
+
+            { "apiVersion": "network.openshift.io/v1",
+                "host": <cluster node-name, 
+                "hostIP": "x.x.x.x",
+                "kind": "HostSubnet",
+                "metadata": {
+            "annotations": {
+                            ...
+            },
+                "subnet": "10.129.0.0/23"
+            }
+3. If the CRD does not exist with the expected specification, `feature-node-watch` might not work for OpenShfit-SDN CNI. In that case, you must manually configure the static routes on Citrix ADC VPX.

--- a/multicluster/Manifest/gtp-crd.yaml
+++ b/multicluster/Manifest/gtp-crd.yaml
@@ -93,6 +93,12 @@ spec:
                           - ROUNDROBIN
                           - STATICPROXIMITY
                           description: "The traffic distribution policy supported in multi-cluster deployment"
+                        sourceIpPersistenceId:
+                          type: integer
+                          minimum: 0
+                          maximum: 65535
+                          multipleOf : 100
+                          description: "Unique SourceIP persistence ID. This enables persistence based on the source IP address for inbound packets"
                         secLbMethod:
                           type: string
                           description: "The traffic distribution policy supported among clusters under a group in local-first, canary or failover"
@@ -144,4 +150,6 @@ spec:
                       type: object
                   type: object
                 type: array
+              status:
+                type: object
             type: object


### PR DESCRIPTION
Updated the doc changes for CIC release 1.21.9

- Multicluster changes for source IP persistence and updated the gtp CRD
- Removed the limitation from Openshift docs for OVN CNI
- Updated the troubleshooting section with workarounds for OVN CNI issues