### PR TITLE
updated command policy link to Citrix ADC doc

### DIFF
--- a/cd/canary-azure-devops/kubernetes_configs/cic_helm/README.md
+++ b/cd/canary-azure-devops/kubernetes_configs/cic_helm/README.md
@@ -103,6 +103,7 @@ To create the system user account, do the following:
 
     **Note**: The system user account would have privileges based on the command policy that you define.
     The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with additional permission to upload files.
+    For more information on command policy, see the [Citrix ADC documentation](https://docs.citrix.com/en-us/citrix-adc/current-release/system/authentication-and-authorization-for-system-user/user-usergroups-command-policies.html#configure-command-policies).
 
     In the command policy specification provided, special characters which need to be escaped are already omitted to easily copy-paste into the Citrix ADC command line.
 

--- a/docs/deploy/deploy-cic-helm.md
+++ b/docs/deploy/deploy-cic-helm.md
@@ -66,7 +66,7 @@ The Citrix ingress controller configures the Citrix ADC using a system user acco
 
     **Note**: The system user account would have privileges based on the command policy that you define.
 
-    The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with additional permission to upload files.
+    The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with additional permission to upload files.  For more information on command policy, see the [Citrix ADC documentation](https://docs.citrix.com/en-us/citrix-adc/current-release/system/authentication-and-authorization-for-system-user/user-usergroups-command-policies.html#configure-command-policies).
 
     In the command policy specification provided, special characters which need to be escaped are already omitted to easily copy-paste into the Citrix ADC command line.
 

--- a/docs/deploy/deploy-cic-openshift-operator.md
+++ b/docs/deploy/deploy-cic-openshift-operator.md
@@ -94,7 +94,7 @@ To create the system user account, perform the following:
 
     **Note**: The system user account would have privileges based on the command policy that you define.
 
-    The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with another permission to upload files.
+    The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with another permission to upload files. For more information on command policy, see the [Citrix ADC documentation](https://docs.citrix.com/en-us/citrix-adc/current-release/system/authentication-and-authorization-for-system-user/user-usergroups-command-policies.html#configure-command-policies).
 
     In the command policy specification provided, special characters which need to be escaped are already omitted to easily copy-paste into the Citrix ADC command line.
 

--- a/docs/deploy/deploy-cic-openshift.md
+++ b/docs/deploy/deploy-cic-openshift.md
@@ -170,7 +170,7 @@ The Citrix ingress controller configures a Citrix ADC appliance (MPX or VPX) usi
 
     **Note**: The system user account would have privileges based on the command policy that you define.
     
-    The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with another permission to upload files.
+    The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with another permission to upload files.  For more information on command policy, see the [Citrix ADC documentation](https://docs.citrix.com/en-us/citrix-adc/current-release/system/authentication-and-authorization-for-system-user/user-usergroups-command-policies.html#configure-command-policies).
 
     In the command policy specification provided, special characters which need to be escaped are already omitted to easily copy-paste into the Citrix ADC command line.
 

--- a/docs/deploy/deploy-cic-yaml.md
+++ b/docs/deploy/deploy-cic-yaml.md
@@ -62,6 +62,7 @@ To create the system user account, perform the following:
     **Note**: The system user account would have privileges based on the command policy that you define.
 
     The command policy mentioned in ***step 3*** is similar to the built-in `sysAdmin` command policy with additional permission to upload files.
+    For more information on command policy, see the [Citrix ADC documentation](https://docs.citrix.com/en-us/citrix-adc/current-release/system/authentication-and-authorization-for-system-user/user-usergroups-command-policies.html#configure-command-policies).
 
     In the command policy specification provided, special characters which need to be escaped are already omitted to easily copy-paste into the Citrix ADC command line.
 


### PR DESCRIPTION
added a link to the Citrix ADC documentation for command policy in
deploy cic files

