### PR TITLE
Removed the csvserver annotation from example

### DIFF
--- a/docs/how-to/tcp-udp-ingress.md
+++ b/docs/how-to/tcp-udp-ingress.md
@@ -125,7 +125,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    ingress.citrix.com/csvserver: '{"l2conn":"on"}'
     ingress.citrix.com/frontend-ip: "192.168.1.1"
     ingress.citrix.com/insecure-port: "80"
     ingress.citrix.com/lbvserver: '{"mongodb-svc":{"lbmethod":"SRCIPDESTIPHASH"}}'


### PR DESCRIPTION
Removed the ingress.citrix.com/csvserver: '{"l2conn":"on"}' annotation from the TCP-UDP ingress page. As per feedback, this annotation is not required.